### PR TITLE
59 add support model relationships

### DIFF
--- a/digitalpy/core/domain/relationship.py
+++ b/digitalpy/core/domain/relationship.py
@@ -1,0 +1,73 @@
+"""this module defines a decorator to create a relationship between two entities, this will act similarly to the property decorator in python except
+that it will allow the definition of uml properties in the relationship such as multiplicity and type, these properties will be used to define runtime
+validation of the relationship
+"""
+from enum import Enum
+import functools
+
+class RelationshipType(Enum):
+    """this class is used to define the type of a relationship, it is an enumeration of the possible relationship
+    types
+    """
+    AGGREGATION = "aggregation"
+    COMPOSITION = "composition"
+    ASSOCIATION = "association"
+
+class Relationship:
+    """
+    A decorator class that represents a relationship between two entities. This class is used as a 
+    decorator to define the getter, setter, and deleter for the relationship.
+    """
+    def __init__(self, fget=None, fset=None, fdel=None, multiplicity_upper: int=1, multiplicity_lower: int=0, reltype: str = RelationshipType.ASSOCIATION):
+        if type not in RelationshipType:
+            raise ValueError("invalid relationship type")
+        self.fget = fget
+        self.fset = fset
+        self.fdel = fdel
+        self.multiplicity_lower = multiplicity_lower
+        self.multiplicity_upper = multiplicity_upper
+        self.type = reltype
+        if fget is not None:
+            functools.update_wrapper(self, fget)
+
+    def __get__(self, obj, objtype=None):
+        if self.fget is None:
+            raise AttributeError("unreadable attribute")
+        return self.fget(obj)
+    
+    def __set__(self, obj, value):
+        if self.fset is None:
+            raise AttributeError("can't set attribute")
+        
+        obj_more_than_one = isinstance(obj, str) or not hasattr(obj, '__len__')
+
+        if self.multiplicity_lower>1 and obj_more_than_one:
+            raise ValueError(f"This property has a lower multiplicity of {self.multiplicity_lower}")
+        
+        if obj_more_than_one and len(obj)<self.multiplicity_upper:
+            raise ValueError(f"This property has an upper multiplicity of {self.multiplicity_upper}")
+
+        self.fset(obj, value)
+
+    def __delete__(self, obj):
+        if self.fdel is None:
+            raise AttributeError("can't delete attribute")
+        self.fdel(obj)
+
+    def getter(self, fget=None):
+        return type(self)(fget=fget, fset=self.fset, fdel=self.fdel, multiplicity_upper=self.multiplicity_upper, multiplicity_lower=self.multiplicity_lower, reltype=self.type)
+
+    def setter(self, fset=None):
+        return type(self)(fget=self.fget, fset=fset, fdel=self.fdel, multiplicity_upper=self.multiplicity_upper, multiplicity_lower=self.multiplicity_lower, reltype=self.type)
+
+    def deleter(self, fdel=None):
+        return type(self)(fget=self.fget, fset=self.fset, fdel=fdel, multiplicity_upper=self.multiplicity_upper, multiplicity_lower=self.multiplicity_lower, reltype=self.type)
+    
+    def __call__(self, func):
+        if not self.fget:
+            self.fget = func
+        elif not self.fset:
+            self.fset = func
+        elif not self.fdel:
+            self.fdel = func
+        return self

--- a/digitalpy/core/domain/relationship.py
+++ b/digitalpy/core/domain/relationship.py
@@ -18,12 +18,13 @@ class Relationship:
     A decorator class that represents a relationship between two entities. This class is used as a 
     decorator to define the getter, setter, and deleter for the relationship.
     """
-    def __init__(self, fget=None, fset=None, fdel=None, multiplicity_upper: int=1, multiplicity_lower: int=0, reltype: str = RelationshipType.ASSOCIATION):
-        if type not in RelationshipType:
+    def __init__(self, fget=None, fset=None, fdel=None, multiplicity_upper: int=1, multiplicity_lower: int=0, reltype: RelationshipType = RelationshipType.ASSOCIATION, navigable: bool = True):
+        if reltype not in iter(RelationshipType):
             raise ValueError("invalid relationship type")
         self.fget = fget
         self.fset = fset
         self.fdel = fdel
+        self.navigable = navigable
         self.multiplicity_lower = multiplicity_lower
         self.multiplicity_upper = multiplicity_upper
         self.type = reltype
@@ -33,35 +34,48 @@ class Relationship:
     def __get__(self, obj, objtype=None):
         if self.fget is None:
             raise AttributeError("unreadable attribute")
+        if not self.navigable:
+            raise AttributeError("this relationship is not navigable")
         return self.fget(obj)
     
     def __set__(self, obj, value):
         if self.fset is None:
             raise AttributeError("can't set attribute")
         
-        obj_more_than_one = isinstance(obj, str) or not hasattr(obj, '__len__')
+        obj_more_than_one = not isinstance(value, str) and hasattr(value, '__len__')
 
-        if self.multiplicity_lower>1 and obj_more_than_one:
-            raise ValueError(f"This property has a lower multiplicity of {self.multiplicity_lower}")
+        if obj_more_than_one:
+            if len(value)<self.multiplicity_lower:
+                raise ValueError(f"This property has a lower multiplicity of {self.multiplicity_lower}")
         
-        if obj_more_than_one and len(obj)<self.multiplicity_upper:
-            raise ValueError(f"This property has an upper multiplicity of {self.multiplicity_upper}")
+            if  len(value)>self.multiplicity_upper:
+                raise ValueError(f"This property has an upper multiplicity of {self.multiplicity_upper}")
+        else:
+            if self.multiplicity_lower>1:
+                raise ValueError(f"This property has a lower multiplicity of {self.multiplicity_lower}")
+            if self.multiplicity_upper>1:
+                raise ValueError(f"This property has an upper multiplicity of {self.multiplicity_upper}")
+            
+        if self.type == RelationshipType.COMPOSITION and value is not None:
+            raise ValueError("composition relationships can't be set directly")
 
         self.fset(obj, value)
 
     def __delete__(self, obj):
         if self.fdel is None:
             raise AttributeError("can't delete attribute")
+        if self.type == RelationshipType.COMPOSITION:
+            raise ValueError("composition relationships can't be deleted directly")
         self.fdel(obj)
 
     def getter(self, fget=None):
-        return type(self)(fget=fget, fset=self.fset, fdel=self.fdel, multiplicity_upper=self.multiplicity_upper, multiplicity_lower=self.multiplicity_lower, reltype=self.type)
+        return type(self)(fget=fget, fset=self.fset, fdel=self.fdel, multiplicity_upper=self.multiplicity_upper, multiplicity_lower=self.multiplicity_lower, reltype=self.type, navigable=self.navigable)
 
     def setter(self, fset=None):
-        return type(self)(fget=self.fget, fset=fset, fdel=self.fdel, multiplicity_upper=self.multiplicity_upper, multiplicity_lower=self.multiplicity_lower, reltype=self.type)
+        return type(self)(fget=self.fget, fset=fset, fdel=self.fdel, multiplicity_upper=self.multiplicity_upper, multiplicity_lower=self.multiplicity_lower, reltype=self.type, navigable=self.navigable)
 
     def deleter(self, fdel=None):
-        return type(self)(fget=self.fget, fset=self.fset, fdel=fdel, multiplicity_upper=self.multiplicity_upper, multiplicity_lower=self.multiplicity_lower, reltype=self.type)
+        return type(self)(fget=self.fget, fset=self.fset, fdel=fdel, multiplicity_upper=self.multiplicity_upper, multiplicity_lower=self.multiplicity_lower, reltype=self.type, navigable=self.navigable)
     
     def __call__(self, func):
         if not self.fget:

--- a/tests/test_domain/test_relationship.py
+++ b/tests/test_domain/test_relationship.py
@@ -1,0 +1,66 @@
+import pytest
+from digitalpy.core.domain.relationship import Relationship, RelationshipType
+
+class TestOneEntity:
+    @Relationship()
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+
+class TestMultipleEntity:
+    @Relationship(reltype=RelationshipType.ASSOCIATION, multiplicity_lower=1, multiplicity_upper=2)
+    def names(self):
+        return self._names
+
+    @names.setter
+    def names(self, value):
+        self._names = value
+
+class TestUnNavigableEntity:
+    @Relationship(navigable=False)
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+
+def test_relationship_getter_and_setter():
+    entity = TestOneEntity()
+    entity.name = "Test"
+    assert entity.name == "Test"
+
+def test_invalid_relationship_type():
+    with pytest.raises(ValueError):
+        @Relationship(reltype="invalid")
+        def invalid(self):
+            pass
+
+def test_one_to_many_relationship():
+    entity = TestMultipleEntity()
+    entity.names = ["Test1", "Test2"]
+    assert entity.names == ["Test1", "Test2"]
+
+def test_invalid_one_to_many_relationship():
+    entity = TestMultipleEntity()
+    with pytest.raises(ValueError):
+        entity.names = "Test"
+
+def test_invalid_one_to_many_relationship_too_many_rels():
+    entity = TestMultipleEntity()
+    with pytest.raises(ValueError):
+        entity.names = ["Test1", "Test2", "Test3"]
+
+def test_invalid_one_to_many_relationship_too_few_rels():
+    entity = TestMultipleEntity()
+    with pytest.raises(ValueError):
+        entity.names = []
+
+def test_unnavigable_relationship():
+    entity = TestUnNavigableEntity()
+    entity._name = "Test"
+    with pytest.raises(AttributeError):
+        entity.name


### PR DESCRIPTION
### Description
This pull request defines a new decorator for nodes to define relationships similarly to how the property decorator is implemented.

### Functionality
This decorator can be used as follows:
```python
from digitalpy.core.domain.relationship import Relationship, RelationshipType
from digitalpy.core.domain.node import Node

class Parent(Node):
    
    @Relationship(reltype=RelationshipType.ASSOCIATION, multiplicity_lower=2, multiplicity_upper=5)
    def children(self):
        return self._children

    @names.setter
    def children(self, value):
        self._children = value
```

This will restrict any more than five children or any less than two children from being added.

Navigability can be used as follows:
```python
from digitalpy.core.domain.relationship import Relationship, RelationshipType
from digitalpy.core.domain.node import Node

class Parent(Node):
    
    @Relationship(reltype=RelationshipType.ASSOCIATION, navigable=False)
    def hidden(self):
        return self._hidden

    @hidden.setter
    def hidden(self, value):
        self._hidden = hidden

```

now the getter cannot be accessed so any operation such as `print(parent_inst.hidden)` would fail.

