### PR TITLE
69 parsing support for new relationships

### DIFF
--- a/digitalpy/core/domain/node.py
+++ b/digitalpy/core/domain/node.py
@@ -10,6 +10,9 @@ from digitalpy.core.persistence.persistent_object_proxy import PersistentObjectP
 from digitalpy.core.persistence.build_depth import BuildDepth
 from digitalpy.core.main.object_factory import ObjectFactory
 
+UNLIMITED_OCCURANCES = "*"
+
+
 class Node(DefaultPersistentObject):
     """Node adds the concept of relations to PersistentObject. It is the basic
     component for building object trees (although a Node can have more than one
@@ -36,6 +39,7 @@ class Node(DefaultPersistentObject):
         model=None,
         oid: ObjectId = None,
         initial_data=None,
+        include_oid=True,
     ) -> None:
         """
 
@@ -45,6 +49,7 @@ class Node(DefaultPersistentObject):
             model (_type_, optional): _description_. Defaults to None.
             oid (ObjectId, optional): _description_. Defaults to None.
             initial_data (_type_, optional): _description_. Defaults to None.
+            include_oid (bool, optional): whether or not to include the oid when getting the properties of the node, if true the oid attribute will be included in all serialization. Defaults to True.
         """
         super().__init__(oid, initial_data)
         if model_configuration is None:
@@ -53,6 +58,10 @@ class Node(DefaultPersistentObject):
         self._parents: Dict[str, Node] = {}
         self._depth = -1
         self._path = ""
+
+        # whether or not to include the oid when getting the properties of the node. this is important
+        # for the serialization of the node
+        self._include_oid = include_oid
         # any extended domain objects which are not defined in the domain
         self._extended = {}
         # default the elements to an empty dictionary if the class configuration doesn't exist
@@ -74,18 +83,33 @@ class Node(DefaultPersistentObject):
         """this property sets the extended domain objects which are not defined in the domain"""
         self._extended = value
 
+    @property
+    def oid(self) -> str:
+        """this property returns the object id of the node"""
+        return str(self._oid)
+
+    @oid.setter
+    def oid(self, value: Union[str, ObjectId]):
+        """this property sets the object id of the node"""
+        if isinstance(value, str):
+            self._oid = ObjectId.parse(value)
+        elif isinstance(value, ObjectId):
+            self._oid = value
+
     def _add_relationships(self, configuration: ModelConfiguration, model) -> None:
         for (
             relationship_name,
             relationship_def,
         ) in self._relationship_definition.relationships.items():
             child_class = model[relationship_name]
-            id = str(uuid.uuid1())
-            oid = ObjectFactory.get_instance(
-                "ObjectId", {"id": id, "type": relationship_name}
-            )
-            child_instance = child_class(configuration, model, oid)
-            self.add_child(child_instance)
+            if relationship_def.min_occurs > 0:
+                for _ in range(relationship_def.min_occurs):
+                    id = str(uuid.uuid1())
+                    oid = ObjectFactory.get_instance(
+                        "ObjectId", {"id": id, "type": relationship_name}
+                    )
+                    child_instance = child_class(configuration, model, oid)
+                    setattr(self, relationship_name, child_instance)
 
     def get_first_child(self, child_type, values, properties, use_regex=True):
         """Get the first child that matches given conditions."""
@@ -167,10 +191,9 @@ class Node(DefaultPersistentObject):
         else:
             return len(self._children)
 
-    def add_child(self, child):
+    def add_child(self, child: 'Node'):
         if self.validate_child_addition(child):
-            self._children[child.get_id()] = child
-            setattr(self, child.__class__.__name__, child)
+            self._children[child.oid] = child
             child.set_parent(self)
         else:
             raise TypeError("child must be an instance of Node")
@@ -183,10 +206,12 @@ class Node(DefaultPersistentObject):
                     child_type
                 ]
                 children = self.get_children_ex(children_type=child_type)
-                if relationship_requirements.max_occurs == len(children):
-                    return False
+                if relationship_requirements.max_occurs != UNLIMITED_OCCURANCES and relationship_requirements.max_occurs < len(children):
+                    raise ValueError(
+                        "Maximum number of related objects exceeded")
             return True
-        raise TypeError("children must inherit from type Node")
+        else:
+            raise TypeError("children must inherit from type Node")
 
     def delete_child(self, child_id):
         del self._children[child_id]
@@ -946,4 +971,10 @@ class Node(DefaultPersistentObject):
 
     @lru_cache(maxsize=1)
     def get_properties(self):
-        return [k for k, p in type(self).__dict__.items() if isinstance(p, property)]
+        # iterate over all properties of the class and add them to the list then add all properties defined in the node object
+        # NOTE: this will not work with a system using inheritance!
+        properties = [k for k, p in type(
+            self).__dict__.items() if isinstance(p, property)]
+        if self._include_oid is True:
+            properties.append("oid")
+        return properties

--- a/digitalpy/core/domain/relationship.py
+++ b/digitalpy/core/domain/relationship.py
@@ -5,6 +5,7 @@ validation of the relationship
 from enum import Enum
 import functools
 
+
 class RelationshipType(Enum):
     """this class is used to define the type of a relationship, it is an enumeration of the possible relationship
     types
@@ -13,12 +14,14 @@ class RelationshipType(Enum):
     COMPOSITION = "composition"
     ASSOCIATION = "association"
 
+
 class Relationship:
     """
     A decorator class that represents a relationship between two entities. This class is used as a 
     decorator to define the getter, setter, and deleter for the relationship.
     """
-    def __init__(self, fget=None, fset=None, fdel=None, multiplicity_upper: int=1, multiplicity_lower: int=0, reltype: RelationshipType = RelationshipType.ASSOCIATION, navigable: bool = True):
+
+    def __init__(self, fget=None, fset=None, fdel=None, multiplicity_upper: int = 1, multiplicity_lower: int = 0, reltype: RelationshipType = RelationshipType.ASSOCIATION, navigable: bool = True):
         if reltype not in iter(RelationshipType):
             raise ValueError("invalid relationship type")
         self.fget = fget
@@ -37,25 +40,30 @@ class Relationship:
         if not self.navigable:
             raise AttributeError("this relationship is not navigable")
         return self.fget(obj)
-    
+
     def __set__(self, obj, value):
         if self.fset is None:
             raise AttributeError("can't set attribute")
-        
-        obj_more_than_one = not isinstance(value, str) and hasattr(value, '__len__')
+
+        obj_more_than_one = not isinstance(
+            value, str) and hasattr(value, '__len__')
 
         if obj_more_than_one:
-            if len(value)<self.multiplicity_lower:
-                raise ValueError(f"This property has a lower multiplicity of {self.multiplicity_lower}")
-        
-            if  len(value)>self.multiplicity_upper:
-                raise ValueError(f"This property has an upper multiplicity of {self.multiplicity_upper}")
+            if len(value) < self.multiplicity_lower:
+                raise ValueError(
+                    f"This property has a lower multiplicity of {self.multiplicity_lower}")
+
+            if len(value) > self.multiplicity_upper:
+                raise ValueError(
+                    f"This property has an upper multiplicity of {self.multiplicity_upper}")
         else:
-            if self.multiplicity_lower>1:
-                raise ValueError(f"This property has a lower multiplicity of {self.multiplicity_lower}")
-            if self.multiplicity_upper>1:
-                raise ValueError(f"This property has an upper multiplicity of {self.multiplicity_upper}")
-            
+            if self.multiplicity_lower > 1:
+                raise ValueError(
+                    f"This property has a lower multiplicity of {self.multiplicity_lower}")
+            if self.multiplicity_upper > 1:
+                raise ValueError(
+                    f"This property has an upper multiplicity of {self.multiplicity_upper}")
+
         if self.type == RelationshipType.COMPOSITION and value is not None:
             raise ValueError("composition relationships can't be set directly")
 
@@ -65,7 +73,8 @@ class Relationship:
         if self.fdel is None:
             raise AttributeError("can't delete attribute")
         if self.type == RelationshipType.COMPOSITION:
-            raise ValueError("composition relationships can't be deleted directly")
+            raise ValueError(
+                "composition relationships can't be deleted directly")
         self.fdel(obj)
 
     def getter(self, fget=None):
@@ -76,7 +85,7 @@ class Relationship:
 
     def deleter(self, fdel=None):
         return type(self)(fget=self.fget, fset=self.fset, fdel=fdel, multiplicity_upper=self.multiplicity_upper, multiplicity_lower=self.multiplicity_lower, reltype=self.type, navigable=self.navigable)
-    
+
     def __call__(self, func):
         if not self.fget:
             self.fget = func

--- a/digitalpy/core/serialization/controllers/xml_serialization_controller.py
+++ b/digitalpy/core/serialization/controllers/xml_serialization_controller.py
@@ -222,6 +222,20 @@ class XMLSerializationController(Controller):
                     pass
                 else:
                     xml.attrib[attribName] = str(value)
+
+        for child in node.get_children():
+            tagElement = self._serialize_node(
+                    child, child.__class__.__name__, level=level + 1)
+            # TODO: modify so double underscores are handled differently
+            try:
+                if attribName[0] == "_":
+                    tagElement.tag = "_" + tagElement.tag
+                    xml.append(tagElement)
+            except:
+                pass
+            else:
+                xml.append(tagElement)
+        
         if hasattr(node, "xml_string"):
             # this method combines the xml object parsed from
             # the model object with the xml_string found in the node

--- a/digitalpy/core/zmanager/impl/zmq_subscriber.py
+++ b/digitalpy/core/zmanager/impl/zmq_subscriber.py
@@ -151,7 +151,7 @@ class ZmqSubscriber(Subscriber):
 
                 topic = message[0]
                 decoded_topic = topic.decode("utf-8")
-                topic_sections = decoded_topic.split("/")
+                topic_sections = decoded_topic.split("/", 9)
                 _, _, service_id, protocol, sender, context, action, id, recipients = topic_sections
                 response.set_sender(sender)
                 response.set_context(context)


### PR DESCRIPTION
## Description
This PR updates the support for serialization and deserialization based on the new relationship decorator. There's also a change to the node in order to make oid access easier and a bug fix for the zmq_subscriber `broker_receive` method to prevent errors in the event a message contains extra `/` characters.