### PR TITLE
70 fix oid parsing and serialization

### DIFF
--- a/digitalpy/core/domain/object_id.py
+++ b/digitalpy/core/domain/object_id.py
@@ -9,7 +9,7 @@ class ObjectId:
     DELIMITER = ":"
 
     __dummy_id_pattern = "DigitalPy[A-Za-z0-9]{32}"
-    __id_pattern = ".*"
+    __id_pattern = r'.*'
     __delimiter_pattern = ":"
     _num_pk_keys = {}
     __null_oid = None
@@ -39,12 +39,14 @@ class ObjectId:
         self.str_val = self.__str__()
 
     def __str__(self):
-        oid_str = self.__fq_type + ObjectId.DELIMITER + \
-            ObjectId.DELIMITER.join(self.id)
-        if len(self.prefix.strip()) > 0:
-            oid_str = self.prefix + ObjectId.DELIMITER + oid_str
+        if hasattr(self, "str_val") and self.str_val != None:
+            return self.str_val
+        oid_str = self.__fq_type + self.DELIMITER + \
+            self.DELIMITER.join(self.id)
+        if self.prefix and self.prefix.strip():
+            oid_str = self.prefix + self.DELIMITER + oid_str
         self.str_val = oid_str
-        return self.str_val
+        return oid_str
 
     def get_id(self) -> list[str]:
         return self.id
@@ -93,6 +95,7 @@ class ObjectId:
 
     @staticmethod
     def parse(oid) -> Union['ObjectId', None]:
+        # fast checks first
         if isinstance(oid, ObjectId):
             return oid
 
@@ -100,9 +103,9 @@ class ObjectId:
         if not oid_parts:
             return None
 
-        type = oid_parts["type"]
-        ids = oid_parts["id"]
-        prefix = oid_parts["prefix"]
+        type = oid_parts['type']
+        ids = oid_parts['id']
+        prefix = oid_parts['prefix']
 
         # Sections commented out as the persistence facade is not yet implemented
         # if not ObjectFactory.get_instance("persistence_facade").is_known_type(type):

--- a/tests/test_domain/test_object_id.py
+++ b/tests/test_domain/test_object_id.py
@@ -1,0 +1,29 @@
+import pytest
+from digitalpy.core.domain.object_id import ObjectId
+
+
+def test_object_id_init():
+    obj_id = ObjectId("User", ["123"], "")
+    assert obj_id.get_type() == "User"
+    assert obj_id.get_id() == ["123"]
+    assert obj_id.get_delimiter_pattern() == ":"
+
+def test_object_id_str():
+    obj_id = ObjectId("User", ["123"], "")
+    assert str(obj_id) == "User:123"
+
+def test_object_id_contains_dummy_ids():
+    obj_id = ObjectId("User", ["123"], "")
+    assert obj_id.contains_dummy_ids() == False
+
+def test_object_id_is_valid():
+    assert ObjectId.is_valid("User:123") == True
+    assert ObjectId.is_valid("InvalidId") == False
+
+def test_object_id_parse():
+    obj_id = ObjectId.parse("User:123")
+    assert obj_id.get_type() == "User"
+    assert obj_id.get_id() == ["123"]
+
+    invalid_obj_id = ObjectId.parse("InvalidId")
+    assert invalid_obj_id == None


### PR DESCRIPTION
## Description
This PR is pretty straight forward. The ObjectId class now has tests and the string method now only separates type and id with the delimiter as opposed to every character in the id.