### PR TITLE
Implement set_format for DefaultRequest

### DIFF
--- a/digitalpy/core/zmanager/impl/default_request.py
+++ b/digitalpy/core/zmanager/impl/default_request.py
@@ -48,4 +48,13 @@ class DefaultRequest(Request):
         return self.method
 
     def set_format(self, format_: str):
+        """Set the serialization format for this request.
+
+        Args:
+            format_ (str): The format name to assign.
+
+        Returns:
+            None
+        """
         self.format = format_
+        return None


### PR DESCRIPTION
## Summary
- fill in `set_format` on DefaultRequest so that requests can store a format string

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684884de8b8883259b9d300b56b92ed0