### PR TITLE
Fix telemetry docstrings

### DIFF
--- a/digitalpy/core/telemetry/tracer.py
+++ b/digitalpy/core/telemetry/tracer.py
@@ -1,10 +1,12 @@
 from abc import ABC, abstractmethod
 from typing import Any
 class Tracer(ABC):
-    
+
     @abstractmethod
     def start_as_current_span(self, span_name: str) -> Any:
-        """this really isnt an abstractmethod however the telemetry system needs to
-        move forward so at least this way refrences can be identified and replaced
-        when/if the time comes that opentelemetry is no longer the target telemetry
-        technology."""
+        """Start a span and set it as the current one.
+
+        This method is not truly abstract; however, the telemetry system
+        requires it so that references can be identified and replaced if the
+        time comes when OpenTelemetry is no longer the target technology.
+        """

--- a/digitalpy/core/telemetry/tracing_provider.py
+++ b/digitalpy/core/telemetry/tracing_provider.py
@@ -5,16 +5,15 @@ class TracingProvider(ABC):
     
     @abstractmethod
     def initialize_tracing(self):
-        """initialize the tracing provider
-        """
+        """Initialize the tracing provider."""
 
     @abstractmethod
     def create_tracer(self, tracer_name: str) -> Tracer:
-        """create a new tracer instance from the current tracer provider
+        """Create a new tracer instance from the current tracer provider.
 
         Args:
-            tracer_name (str): the name to associate with the tracer instance
+            tracer_name (str): The name to associate with the tracer instance.
 
         Returns:
-            Tracer: a new tracer instance with the given name
-        """        
+            Tracer: A new tracer instance with the given name.
+        """


### PR DESCRIPTION
## Summary
- tidy up docstrings in tracing_provider and tracer
- ensure files end with a newline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'digitalpy')*

------
https://chatgpt.com/codex/tasks/task_e_684884eddd548325b2ab477f2f8940f4