### PR TITLE
Align tox configuration with project Python version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,14 @@
 [tox]
-envlist = py39
+envlist = py310
 skipsdist = True
  
 [testenv]
+basepython = python3.10
 deps =
     pytest
     pytest-cov
     coverage
     -e .
 commands = pytest --cov=. --cov-report=xml tests/
-
- 
 [tool.coverage.run]
 relative_files = true


### PR DESCRIPTION
## Summary
- set `py310` env in `tox.ini`
- make tox use Python 3.10 interpreter
- fix coverage section formatting

## Testing
- `tox -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6848873498488325a20911b5fc04afb6