### PR TITLE
Add app configuration helpers

### DIFF
--- a/digitalpy/core/main/impl/default_factory.py
+++ b/digitalpy/core/main/impl/default_factory.py
@@ -179,7 +179,11 @@ class DefaultFactory(Factory):
                         if getattr(instance, setter_name, None) != None:
                             getattr(instance, setter_name)(value)
                         else:
-                            setattr(instance, key, value)
+                            try:
+                                setattr(instance, key, value)
+                            except AttributeError:
+                                # attribute might be a read-only property
+                                pass
         else:
             # TODO: figure out the cases for a mapping being called and how to implement
             interface = self.get_interface(name)

--- a/examples/filmology_app/main.py
+++ b/examples/filmology_app/main.py
@@ -6,6 +6,9 @@ which serves as the entry point for the application.
 """
 
 from digitalpy.core.main.DigitalPy import DigitalPy
+from digitalpy.core.main.singleton_configuration_factory import (
+    SingletonConfigurationFactory,
+)
 
 
 class FilmologyApp(DigitalPy):
@@ -25,6 +28,23 @@ class FilmologyApp(DigitalPy):
         """
         super().__init__()
         self._initialize_app_configuration()
+
+    def _initialize_app_configuration(self):
+        """Load the application specific configuration."""
+        super()._initialize_app_configuration()
+
+        self.configuration.set_value(
+            "blueprint_import_base",
+            "filmology_app.blueprints",
+            "digitalpy.core_api",
+        )
+
+        component_management_conf = (
+            SingletonConfigurationFactory.get_configuration_object(
+                "ComponentManagementConfiguration"
+            )
+        )
+        component_management_conf.component_import_root = "filmology_app.components"
 
 if __name__ == "__main__":
     # Entry point for the DigitalPy application.

--- a/examples/minimal_dp_app/configuration/application_configuration.ini
+++ b/examples/minimal_dp_app/configuration/application_configuration.ini
@@ -16,3 +16,6 @@
 ; [ServiceManagementConfiguration]
 ; __class = digitalpy.core.service_management.domain.model.service_management_configuration.ServiceManagementConfiguration
 ; services = [dp_helloworld.simple_tcp]
+
+[ComponentManagementConfiguration]
+component_import_root = minimal_dp_app.components

--- a/examples/minimal_dp_app/configuration/object_configuration.ini
+++ b/examples/minimal_dp_app/configuration/object_configuration.ini
@@ -13,3 +13,6 @@
 ;[digitalpy.core_api]
 ;blueprint_path = NewPath/To/My/blueprints/
 ;blueprint_import_base = MyDifferentRoute.blueprints
+
+[digitalpy.core_api]
+blueprint_import_base = minimal_dp_app.blueprints

--- a/examples/minimal_dp_app/main.py
+++ b/examples/minimal_dp_app/main.py
@@ -6,6 +6,9 @@ which serves as the entry point for the application.
 """
 
 from digitalpy.core.main.DigitalPy import DigitalPy
+from digitalpy.core.main.singleton_configuration_factory import (
+    SingletonConfigurationFactory,
+)
 
 
 class DigitalPyApp(DigitalPy):
@@ -25,6 +28,25 @@ class DigitalPyApp(DigitalPy):
         """
         super().__init__()
         self._initialize_app_configuration()
+
+    def _initialize_app_configuration(self):
+        """Load the application specific configuration."""
+        super()._initialize_app_configuration()
+
+        # ensure the core API imports blueprints from this app
+        self.configuration.set_value(
+            "blueprint_import_base",
+            "minimal_dp_app.blueprints",
+            "digitalpy.core_api",
+        )
+
+        # set the component import root so components can be loaded
+        component_management_conf = (
+            SingletonConfigurationFactory.get_configuration_object(
+                "ComponentManagementConfiguration"
+            )
+        )
+        component_management_conf.component_import_root = "minimal_dp_app.components"
 
 if __name__ == "__main__":
     # Entry point for the DigitalPy application.

--- a/examples/reticulum_app/configuration/object_configuration.ini
+++ b/examples/reticulum_app/configuration/object_configuration.ini
@@ -14,6 +14,9 @@
 ;blueprint_path = NewPath/To/My/blueprints/
 ;blueprint_import_base = MyDifferentRoute.blueprints
 
+[digitalpy.core_api]
+blueprint_import_base = reticulum_app.blueprints
+
 [reticulum_app.reticulum]
 __class = reticulum_app.services.reticulum_service.ReticulumService
 identity_path = .identity

--- a/examples/reticulum_app/main.py
+++ b/examples/reticulum_app/main.py
@@ -6,6 +6,9 @@ which serves as the entry point for the application.
 """
 
 from digitalpy.core.main.DigitalPy import DigitalPy
+from digitalpy.core.main.singleton_configuration_factory import (
+    SingletonConfigurationFactory,
+)
 
 
 class DigitalPyApp(DigitalPy):
@@ -25,6 +28,23 @@ class DigitalPyApp(DigitalPy):
         """
         super().__init__()
         self._initialize_app_configuration()
+
+    def _initialize_app_configuration(self):
+        """Load the application specific configuration."""
+        super()._initialize_app_configuration()
+
+        self.configuration.set_value(
+            "blueprint_import_base",
+            "reticulum_app.blueprints",
+            "digitalpy.core_api",
+        )
+
+        component_management_conf = (
+            SingletonConfigurationFactory.get_configuration_object(
+                "ComponentManagementConfiguration"
+            )
+        )
+        component_management_conf.component_import_root = "reticulum_app.components"
 
 if __name__ == "__main__":
     # Entry point for the DigitalPy application.


### PR DESCRIPTION
## Summary
- add `_initialize_app_configuration()` methods to example apps
- set component import roots and blueprint bases in configs
- ignore read-only attribute errors in `DefaultFactory`
- verify minimal example runs

## Testing
- `timeout 5s python examples/minimal_dp_app/main.py`
- `pytest -q` *(fails: 1 failed, 109 passed, 8 skipped, 3 warnings, 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68489890aad0832598d6a6b9a9d70c55