### PR TITLE
fix: Python 3.13 compatibility (pkg_resources + ObjectFactory)

### DIFF
--- a/digitalpy/core/component_management/controllers/component_manifest_controller.py
+++ b/digitalpy/core/component_management/controllers/component_manifest_controller.py
@@ -1,7 +1,7 @@
 from io import TextIOBase
 from typing import TYPE_CHECKING
 
-import pkg_resources
+from importlib.metadata import version as _get_version
 
 from digitalpy.core.component_management.configuration.component_management_constants import (
     DIGITALPY,
@@ -116,7 +116,7 @@ class ComponentManifestController(Controller):
             bool: True if the version is valid, False otherwise
         """
         # retrieve the current digitalpy version based on the setup.py
-        digitalpy_version = pkg_resources.require(DIGITALPY)[0].version
+        digitalpy_version = _get_version(DIGITALPY)
         required_version_sections = required_version.split(VERSION_DELIMITER)
         # iterate the delimited version number and compare it to the digitalpy version
         for i, _ in enumerate(required_version_sections):

--- a/digitalpy/core/component_management/impl/component_registration_handler.py
+++ b/digitalpy/core/component_management/impl/component_registration_handler.py
@@ -2,7 +2,7 @@ import importlib
 import os
 from pathlib import PurePath
 from typing import Dict, List
-import pkg_resources
+from importlib.metadata import version as _get_version
 
 from digitalpy.core.main.registration_handler import RegistrationHandler
 from digitalpy.core.component_management.impl.default_facade import DefaultFacade
@@ -136,7 +136,7 @@ class ComponentRegistrationHandler(RegistrationHandler):
             tuple[bool, bool]: whether the component is compatible with the current digitalpy installation and whether the component has any pending dependencies
         """
         # retrieve the current digitalpy version based on the setup.py
-        digitalpy_version = pkg_resources.require(DIGITALPY)[0].version
+        digitalpy_version = _get_version(DIGITALPY)
 
         try:
             # get the manifest section from the configuration

--- a/digitalpy/core/main/object_factory.py
+++ b/digitalpy/core/main/object_factory.py
@@ -5,7 +5,7 @@ from typing import Any
 class ObjectFactory:
     """ObjectFactory class to create and retrieve instances."""
     
-    __factory: Factory
+    __factory: Factory = None
 
     @staticmethod
     def configure(factory: Factory):

--- a/digitalpy/core/service_management/service_registration_handler.py
+++ b/digitalpy/core/service_management/service_registration_handler.py
@@ -2,7 +2,7 @@ import importlib
 import os
 from pathlib import PurePath
 from typing import List
-import pkg_resources
+from importlib.metadata import version as _get_version
 
 from digitalpy.core.main.registration_handler import RegistrationHandler
 from digitalpy.core.component_management.impl.default_facade import DefaultFacade
@@ -118,7 +118,7 @@ class ServiceRegistrationHandler(RegistrationHandler):
             bool: whether the service is compatible with the current digitalpy installation
         """
         # retrieve the current digitalpy version based on the setup.py
-        digitalpy_version = pkg_resources.require(DIGITALPY)[0].version
+        digitalpy_version = _get_version(DIGITALPY)
 
         try:
             # get the manifest section from the configuration


### PR DESCRIPTION
- ObjectFactory.__factory needs explicit None default value (Python 3.13 stricter about class variable annotations without values)
- Replace pkg_resources with importlib.metadata (pkg_resources removed from setuptools 82.x)